### PR TITLE
Mention pupa-cli in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,11 @@ Data to interpolate into `template`.
 Template literals expand on creation. This module expands the template on execution, which can be useful if either or both template and data are lazily created or user-supplied.
 
 
+## Related
+
+- [pupa-cli](https://github.com/sonicdoe/pupa-cli) - CLI for this module
+
+
 ## License
 
 MIT © [Sindre Sorhus](https://sindresorhus.com)


### PR DESCRIPTION
I’ve written a small CLI for pupa over at [sonicdoe/pupa-cli](https://github.com/sonicdoe/pupa-cli). For example:

```console
$ echo 'The answer is {answer}.' | pupa --answer 42
The answer is 42.
```

If you’re fine with that, I’d publish the package to npm and we could mention it as a related project here 🙂