### PR TITLE
Import index file with `.`

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import m from './';
+import m from '.';
 
 test(t => {
 	t.is(m('{foo}', {foo: '!'}), '!');


### PR DESCRIPTION
Fixes the XO test, see [unicorn/import-index](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v4.0.3/docs/rules/import-index.md).