### PR TITLE
support {object_with_array[0].asproperty}

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,12 +9,18 @@ module.exports = (tpl, data) => {
 	}
 
 	const re = /{(.*?)}/g;
+	const array_re = /^([a-zA-Z0-9]*)\[(.*)\]$/;
 
 	return tpl.replace(re, (_, key) => {
 		let ret = data;
 
 		for (const prop of key.split('.')) {
-			ret = ret ? ret[prop] : '';
+			if(prop.match(array_re)) {
+		                let matching = array_re.exec(prop);
+                		ret = ret[ matching[1] ] [ matching[2] ];
+            		} else {
+                		ret = ret ? ret[prop] : '';
+            		}
 		}
 
 		return ret || '';


### PR DESCRIPTION
like pupa("{results[0].field1", {results:[{field1:"val",field2:"val"},{field1:"v",field2:"v2"}]});