### PR TITLE
Encode HTML entities inside placeholder when using double braces

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,30 @@ module.exports = (template, data) => {
 		throw new TypeError(`Expected an Object/Array in the second argument, got ${typeof data}`);
 	}
 
+	const HTMLregex = /{{(.*?)}}/g
+
+	if (HTMLregex.test(template)) {
+		template = template.replace(HTMLregex, (_, key) => {
+			let ret = data;
+	
+			for (const prop of key.split('.')) {
+				ret = ret ? ret[prop] : '';
+			}
+			
+			// Encoding HTML Entities to avoid code injection
+			ret = ret.replace(/[&"<>]/g, (c) => {
+				return {
+					'&': "&amp;",
+					'"': "&quot;",
+					'<': "&lt;",
+					'>': "&gt;"
+				}[c];
+			});
+
+			return ret || '';
+		});
+	}
+	
 	const regex = /{(.*?)}/g;
 
 	return template.replace(regex, (_, key) => {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const escapeGoat = require('escape-goat');
+
 module.exports = (template, data) => {
 	if (typeof template !== 'string') {
 		throw new TypeError(`Expected a string in the first argument, got ${typeof template}`);
@@ -19,15 +21,7 @@ module.exports = (template, data) => {
 			}
 
 			// Encoding HTML Entities to avoid code injection
-			const HTMLentities = /[&"<>]/g;
-			ret = ret.toString().replace(HTMLentities, c => {
-				return {
-					'&': '&amp;',
-					'"': '&quot;',
-					'<': '&lt;',
-					'>': '&gt;'
-				}[c];
-			});
+			ret = escapeGoat.escape(ret);
 
 			return ret || '';
 		});

--- a/index.js
+++ b/index.js
@@ -9,30 +9,30 @@ module.exports = (template, data) => {
 		throw new TypeError(`Expected an Object/Array in the second argument, got ${typeof data}`);
 	}
 
-	const HTMLregex = /{{(.*?)}}/g
+	const HTMLregex = /{{(.*?)}}/g;
 
 	if (HTMLregex.test(template)) {
 		template = template.replace(HTMLregex, (_, key) => {
 			let ret = data;
-	
 			for (const prop of key.split('.')) {
 				ret = ret ? ret[prop] : '';
 			}
-			
+
 			// Encoding HTML Entities to avoid code injection
-			ret = ret.replace(/[&"<>]/g, (c) => {
+			const HTMLentities = /[&"<>]/g;
+			ret = ret.toString().replace(HTMLentities, c => {
 				return {
-					'&': "&amp;",
-					'"': "&quot;",
-					'<': "&lt;",
-					'>': "&gt;"
+					'&': '&amp;',
+					'"': '&quot;',
+					'<': '&lt;',
+					'>': '&gt;'
 				}[c];
 			});
 
 			return ret || '';
 		});
 	}
-	
+
 	const regex = /{(.*?)}/g;
 
 	return template.replace(regex, (_, key) => {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = (template, data) => {
 			}
 
 			// Encoding HTML Entities to avoid code injection
-			ret = escapeGoat.escape(ret);
+			ret = escapeGoat.escape(ret.toString());
 
 			return ret || '';
 		});

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
 	"devDependencies": {
 		"ava": "^0.25.0",
 		"xo": "^0.23.0"
+	},
+	"dependencies": {
+		"escape-goat": "^1.3.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -29,11 +29,8 @@ pupa('I like {0} and {1}', ['🦄', '🐮']);
 //=> 'I like 🦄 and 🐮'
 
 // Double braces encodes the HTML entities to avoid code injection.
-pupa('{{0}}{{1}}', ['<br>yo</br>', '<i>lol</i>']);
-//=> '&lt;b&gt;yo&lt;/b&gt;&lt;b&gt;lol&lt;/b&gt;
-
-pupa('yo {{foo}} lol {{bar}} sup', {foo: '🦄', bar: '🌈'});
-//=> 'yo 🦄 lol 🌈 sup's
+pupa('I like {{0}} and {{1}}', ['<br>🦄</br>', '<i>🐮</i>']);
+//=> 'I like &lt;br&gt;🦄&lt;/br&gt; and &lt;i&gt;🐮&lt;/i&gt;'
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ pupa('The mobile number of {name} is {phone.mobile}', {
 pupa('I like {0} and {1}', ['🦄', '🐮']);
 //=> 'I like 🦄 and 🐮'
 
-//	Double braces encodes the HTML entities to avoid code injection.
+// Double braces encodes the HTML entities to avoid code injection.
 pupa('{{0}}{{1}}', ['<br>yo</br>', '<i>lol</i>']);
 //=> '&lt;b&gt;yo&lt;/b&gt;&lt;b&gt;lol&lt;/b&gt;
 

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,13 @@ pupa('The mobile number of {name} is {phone.mobile}', {
 
 pupa('I like {0} and {1}', ['🦄', '🐮']);
 //=> 'I like 🦄 and 🐮'
+
+//	Double braces encodes the HTML entities to avoid code injection.
+pupa('{{0}}{{1}}', ['<br>yo</br>', '<i>lol</i>']);
+//=> '&lt;b&gt;yo&lt;/b&gt;&lt;b&gt;lol&lt;/b&gt;
+
+pupa('yo {{foo}} lol {{bar}} sup', {foo: '🦄', bar: '🌈'});
+//=> 'yo 🦄 lol 🌈 sup's
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -38,6 +38,6 @@ test('main', t => {
 
 	t.is(pupa('{{0}}{{1}}', ['!', '#']), '!#');
 
-	t.is(pupa('{{0}}{{1}}', ['<br>yo</br>', '<i>lol</i>']), '&lt;b&gt;yo&lt;/b&gt;&lt;b&gt;lol&lt;/b&gt;');
+	t.is(pupa('{{0}}{{1}}', ['<br>yo</br>', '<i>lol</i>']), '&lt;br&gt;yo&lt;/br&gt;&lt;i&gt;lol&lt;/i&gt;');
 });
 

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ import test from 'ava';
 import pupa from '.';
 
 test('main', t => {
+	// Normal placeholder
 	t.is(pupa('{foo}', {foo: '!'}), '!');
 	t.is(pupa('{foo}', {foo: 10}), '10');
 	t.is(pupa('{foo}{foo}', {foo: '!'}), '!!');
@@ -18,5 +19,25 @@ test('main', t => {
 	}), '!#');
 
 	t.is(pupa('{0}{1}', ['!', '#']), '!#');
+
+	// Encoding HTML Entities to avoid code injection
+	t.is(pupa('{{foo}}', {foo: '!'}), '!');
+	t.is(pupa('{{foo}}', {foo: 10}), '10');
+	t.is(pupa('{{foo}}{{foo}}', {foo: '!'}), '!!');
+	t.is(pupa('{foo}{{bar}}{foo}', {foo: '!', bar: '#'}), '!#!');
+	t.is(pupa('yo {{foo}} lol {{bar}} sup', {foo: '🦄', bar: '🌈'}), 'yo 🦄 lol 🌈 sup');
+
+	t.is(pupa('{foo}{{deeply.nested.value}}', {
+		foo: '!',
+		deeply: {
+			nested: {
+				value: '<br>#</br>'
+			}
+		}
+	}), '!&lt;br&gt;#&lt;/br&gt;');
+
+	t.is(pupa('{{0}}{{1}}', ['!', '#']), '!#');
+
+	t.is(pupa('{{0}}{{1}}', ['<br>yo</br>', '<i>lol</i>']), '&lt;b&gt;yo&lt;/b&gt;&lt;b&gt;lol&lt;/b&gt;');
 });
 


### PR DESCRIPTION
This PR fix #4.

Encode HTML entities inside placeholder to avoid code injection when using double braces.

- [x] Update `index.js` to escape HTML.
- [x] Update `test.js` to include tests for the double braces. 
- [x] Update `README` with double braces feature.

The code of HTML escaping is inspired from [this answer](https://stackoverflow.com/a/30970751) on Stackoverflow.