### PR TITLE
Added support for dot in data (Issue #17)

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,13 @@ export default function pupa(template, data, {ignoreMissing = false, transform =
 		throw new TypeError(`Expected an \`object\` or \`Array\` in the second argument, got \`${typeof data}\``);
 	}
 
+	const nestedKeySplitRegex = /(?<!\\)\./gi;
+
 	const replace = (placeholder, key) => {
 		let value = data;
-		for (const property of key.split('.')) {
-			value = value ? value[property] : undefined;
+		for (const property of key.split(nestedKeySplitRegex)) {
+			const propertyWithoutEscape = property.replace('\\', '');
+			value = value ? value[propertyWithoutEscape] : undefined;
 		}
 
 		const transformedValue = transform({value, key});
@@ -38,13 +41,13 @@ export default function pupa(template, data, {ignoreMissing = false, transform =
 	const composeHtmlEscape = replacer => (...args) => htmlEscape(replacer(...args));
 
 	// The regex tries to match either a number inside `{{ }}` or a valid JS identifier or key path.
-	const doubleBraceRegex = /{{(\d+|[a-z$_][\w$]*?(?:\.[\w$]*?)*?)}}/gi;
+	const doubleBraceRegex = /{{(\d+|[a-z$_][\w$]*?(?:\\?\.[\w$]*?)*?)}}/gi;
 
 	if (doubleBraceRegex.test(template)) {
 		template = template.replace(doubleBraceRegex, composeHtmlEscape(replace));
 	}
 
-	const braceRegex = /{(\d+|[a-z$_][\w$]*?(?:\.[\w$]*?)*?)}/gi;
+	const braceRegex = /{(\d+|[a-z$_][\w$]*?(?:\\?\.[\w$]*?)*?)}/gi;
 
 	return template.replace(braceRegex, replace);
 }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ export default function pupa(template, data, {ignoreMissing = false, transform =
 	const replace = (placeholder, key) => {
 		let value = data;
 		for (const property of key.split(nestedKeySplitRegex)) {
-			const propertyWithoutEscape = property.replace('\\', '');
+			const propertyWithoutEscape = property.replace(/\\/g, '');
 			value = value ? value[propertyWithoutEscape] : undefined;
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,24 @@ pupa('I like {0} and {1}', ['🦄', '🐮']);
 // Double braces encodes the HTML entities to avoid code injection.
 pupa('I like {{0}} and {{1}}', ['<br>🦄</br>', '<i>🐮</i>']);
 //=> 'I like &lt;br&gt;🦄&lt;/br&gt; and &lt;i&gt;🐮&lt;/i&gt;'
+
+// If parts of the replacement contains '.', escape the template with \\ (double-backslash).
+pupa('The mobile number of {name} is {user.phone\\.mobile}', {
+	name: 'Sindre',
+	user: {
+		'phone.mobile': '609 24 363',
+	},
+});
+//=> 'The mobile number of Sindre is 609 24 363'
+
+// Works with double braces too
+pupa('The mobile number of {name} is {{user.phone\\.mobile}}', {
+	name: 'Sindre',
+	user: {
+		'phone.mobile': '<b>609 24 363</b>',
+	},
+});
+//=> 'The mobile number of Sindre is &lt;b&gt;609 24 363&lt;/b&gt;');
 ```
 
 ## API

--- a/test.js
+++ b/test.js
@@ -19,6 +19,11 @@ test('main', t => {
 		},
 	}), '!#');
 
+	t.is(pupa('The mobile number of {name} is {phone\\.mobile}', {
+		name: 'Sindre',
+		'phone.mobile': '609 24 363',
+	}), 'The mobile number of Sindre is 609 24 363');
+
 	t.is(pupa('{0}{1}', ['!', '#']), '!#');
 
 	// Encoding HTML Entities to avoid code injection
@@ -37,6 +42,11 @@ test('main', t => {
 			},
 		},
 	}), '!&lt;br&gt;#&lt;/br&gt;');
+
+	t.is(pupa('The mobile number of {name} is {{phone\\.mobile}}', {
+		name: 'Sindre',
+		'phone.mobile': '<b>609 24 363</b>',
+	}), 'The mobile number of Sindre is &lt;b&gt;609 24 363&lt;/b&gt;');
 
 	t.is(pupa('{{0}}{{1}}', ['!', '#']), '!#');
 

--- a/test.js
+++ b/test.js
@@ -24,6 +24,13 @@ test('main', t => {
 		'phone.mobile': '609 24 363',
 	}), 'The mobile number of Sindre is 609 24 363');
 
+	t.is(pupa('The mobile number of {name} is {user.phone\\.mobile}', {
+		name: 'Sindre',
+		user: {
+			'phone.mobile': '609 24 363',
+		},
+	}), 'The mobile number of Sindre is 609 24 363');
+
 	t.is(pupa('{0}{1}', ['!', '#']), '!#');
 
 	// Encoding HTML Entities to avoid code injection
@@ -46,6 +53,13 @@ test('main', t => {
 	t.is(pupa('The mobile number of {name} is {{phone\\.mobile}}', {
 		name: 'Sindre',
 		'phone.mobile': '<b>609 24 363</b>',
+	}), 'The mobile number of Sindre is &lt;b&gt;609 24 363&lt;/b&gt;');
+
+	t.is(pupa('The mobile number of {name} is {{user.phone\\.mobile}}', {
+		name: 'Sindre',
+		user: {
+			'phone.mobile': '<b>609 24 363</b>',
+		},
 	}), 'The mobile number of Sindre is &lt;b&gt;609 24 363&lt;/b&gt;');
 
 	t.is(pupa('{{0}}{{1}}', ['!', '#']), '!#');

--- a/test.js
+++ b/test.js
@@ -31,6 +31,20 @@ test('main', t => {
 		},
 	}), 'The mobile number of Sindre is 609 24 363');
 
+	t.is(pupa('{foo\\.bar} {foo\\.bar\\.baz}', {
+		'foo.bar': 'Foo!',
+		'foo.bar.baz': 'Baz!',
+	}), 'Foo! Baz!');
+
+	t.is(pupa('{foobar.foo} {foobar.escaped.one\\.two\\.three}', {
+		foobar: {
+			foo: 'Unescaped',
+			escaped: {
+				'one.two.three': 'Nested Escaped!',
+			},
+		},
+	}), 'Unescaped Nested Escaped!');
+
 	t.is(pupa('{0}{1}', ['!', '#']), '!#');
 
 	// Encoding HTML Entities to avoid code injection
@@ -61,6 +75,20 @@ test('main', t => {
 			'phone.mobile': '<b>609 24 363</b>',
 		},
 	}), 'The mobile number of Sindre is &lt;b&gt;609 24 363&lt;/b&gt;');
+
+	t.is(pupa('{foo\\.bar} {{foo\\.bar\\.baz}}', {
+		'foo.bar': 'Foo!',
+		'foo.bar.baz': '<b>Baz!</b>',
+	}), 'Foo! &lt;b&gt;Baz!&lt;/b&gt;');
+
+	t.is(pupa('{foobar.foo} {{foobar.escaped.one\\.two\\.three}}', {
+		foobar: {
+			foo: 'Unescaped',
+			escaped: {
+				'one.two.three': '<b>Nested Escaped!</b>',
+			},
+		},
+	}), 'Unescaped &lt;b&gt;Nested Escaped!&lt;/b&gt;');
 
 	t.is(pupa('{{0}}{{1}}', ['!', '#']), '!#');
 


### PR DESCRIPTION
This PR implements the changes required for #17 

Summary of changes:
- Updated the braceRegexes to support escape (\) character
- Updated the template property split functionality to NOT split if the dot is escaped

Fixes #17